### PR TITLE
Fix broken Project Page link

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -21,7 +21,7 @@
       {"name": "Find USGS Sites", "url": "https://maps.waterdata.usgs.gov/mapper/"},
       {
         "name": "Project Page",
-        "url": "https://github.com/NatelEnergy/grafana-usgs-datasource"
+        "url": "https://github.com/NatelEnergy/natel-usgs-datasource"
       },
       {"name": "Natel Energy", "url": "http://www.natelenergy.com/"}
     ],


### PR DESCRIPTION
Likely was not updated after a repository move/rename